### PR TITLE
Add support for testing in Docker containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pytest_cache
+__pycache__
+*.pyc
+*.pyo

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: trusty
+sudo: required
+language: python
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get update && sudo apt-get install -y make
+
+script:
+  - make test-py36
+  - make test-py37
+
+notifications:
+  email: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG PY_VERSION=latest
+FROM python:${PY_VERSION}
+
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y lldb-8 && \
+    ln -s /usr/bin/lldb-8 /usr/bin/lldb && \
+    mkdir -p /root/.lldb/cpython-lldb
+
+COPY *.py /root/.lldb/cpython-lldb/
+RUN echo "command script import /root/.lldb/cpython-lldb/cpython_lldb.py" >> /root/.lldbinit && \
+    chmod +x /root/.lldbinit
+
+CMD ["/usr/bin/lldb"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PY_VERSION := latest
+
+build-image:
+	docker build -t cpython-lldb:$(PY_VERSION) --build-arg PY_VERSION=$(PY_VERSION) .
+
+build-image-py36: PY_VERSION=3.6
+build-image-py36: build-image
+
+build-image-py37: PY_VERSION=3.7
+build-image-py37: build-image
+
+
+test: build-image
+	docker run -t -i --rm \
+		--security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
+		-e PYTHONHASHSEED=1 \
+		cpython-lldb:$(PY_VERSION) \
+		bash -c "cd /root/.lldb/cpython-lldb && python test_cpython_lldb.py -v"
+
+test-py36: PY_VERSION=3.6
+test-py36: test
+
+test-py37: PY_VERSION=3.7
+test-py37: test


### PR DESCRIPTION
Using official Python Docker images + built LLDB packages seems to
be the easiest way to test on different CPython versions, so let's
give it a try.

Tests currently pass on CPython 3.6 and 3.7. 3.4 and 3.5 seem to
have some problems with pretty-printing of dictionaries.