### PR TITLE
fix: target selection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ ARG PY_VERSION=latest
 FROM python:${PY_VERSION}
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main" >> /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y lldb-8 && \
-    ln -s /usr/bin/lldb-8 /usr/bin/lldb && \
+    apt-get install -y lldb-7 && \
+    ln -s /usr/bin/lldb-7 /usr/bin/lldb && \
     mkdir -p /root/.lldb/cpython-lldb
 
 COPY *.py /root/.lldb/cpython-lldb/

--- a/test_cpython_lldb.py
+++ b/test_cpython_lldb.py
@@ -14,9 +14,6 @@ class BaseTestCase(unittest.TestCase):
             sys.executable,
             '-o', 'breakpoint set -r builtin_id',
             '-o', 'run -c "id(%s)"' % (code_value or repr(value)),
-            '-o', 'script import sys',
-            '-o', 'script sys.path.insert(0, "%s")' % os.path.dirname(os.path.abspath(__file__)),
-            '-o', 'command script import cpython_lldb',
             '-o', 'frame info',
             '-o', 'quit'
         ]


### PR DESCRIPTION
It seems that `lldb.target` and `lldb.process` are only correctly
initialized after some `script` command was executed. We cannot expect
users to do so normally, use the variable state explicitly passed
instead of the global state.

This also fixes the docker image build process to not rely on the unstable version. We can probably bump this to lldb-8 again after LLVM 8 hits stable (hopefully next week).