### PR TITLE
handle case if there are no symbols found

### DIFF
--- a/cpython_lldb.py
+++ b/cpython_lldb.py
@@ -531,8 +531,11 @@ def full_backtrace(debugger, command, result, internal_dict):
         lines.append(u'  ' + pyframe.to_pythonlike_string())
         lines.append(u'    ' + pyframe.line.strip())
 
-    print(u'Traceback (most recent call last):')
-    print(u'\n'.join(lines))
+    if lines:
+        print(u'Traceback (most recent call last):')
+        print(u'\n'.join(lines))
+    else:
+        print(u'No Python traceback found (symbols might be missing)!')
 
 
 def __lldb_init_module(debugger, internal_dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,54 @@
+import contextlib
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
 
+import pytest
 
-def run_lldb(code, breakpoint, command):
+
+@contextlib.contextmanager
+def strip_symbols(executable):
+    libpython = subprocess.check_output("ldd %s | grep libpython | awk '{print $3}'" % (executable), shell=True).decode("utf-8").strip()
+    libpython_backup = libpython + ".backup"
+
+    try:
+        subprocess.check_call("cp %s %s" % (libpython, libpython_backup), shell=True)
+        subprocess.check_call("strip -S %s" % (libpython), shell=True)
+        yield
+    except Exception:
+        pytest.skip("Cannot strip symbols")
+
+    subprocess.check_call("cp %s %s" % (libpython_backup, libpython), shell=True)
+
+
+
+def run_lldb(code, breakpoint, command, no_symbols=False):
     old_cwd = os.getcwd()
     d = tempfile.mkdtemp()
     try:
         with open('test.py', 'w') as fp:
             fp.write(code)
+
         args = [
             'lldb',
+        ]
+        if no_symbols:
+            args += ['-o', 'settings set symbols.enable-external-lookup false']
+        args += [
             sys.executable,
             '-o', 'breakpoint set -r %s' % (breakpoint),
             '-o', 'run "test.py"',
             '-o', command,
             '-o', 'quit'
         ]
-        return subprocess.check_output(args).decode('utf-8')
+
+        if no_symbols:
+            with strip_symbols(sys.executable):
+                return subprocess.check_output(args).decode('utf-8')
+        else:
+            return subprocess.check_output(args).decode('utf-8')
     finally:
         os.chdir(old_cwd)
         shutil.rmtree(d, ignore_errors=True)

--- a/tests/test_py_bt.py
+++ b/tests/test_py_bt.py
@@ -12,11 +12,12 @@ def extract_traceback(response):
     return list(itertools.takewhile(before_end, itertools.dropwhile(before_start, lines)))[1:]
 
 
-def assert_backtrace(code, breakpoint, expected):
+def assert_backtrace(code, breakpoint, expected, no_symbols=False):
     response = run_lldb(
         code=code,
         breakpoint=breakpoint,
         command='py-bt',
+        no_symbols=no_symbols,
     )
     actual = u'\n'.join(extract_traceback(response))
 
@@ -111,3 +112,29 @@ Traceback (most recent call last):
     abs(1)'''.lstrip()
 
     assert_backtrace(code, 'builtin_abs', backtrace)
+
+
+def test_without_symbols():
+    code = '''
+def f():
+    abs(1)
+
+f()
+'''.lstrip()
+
+    backtrace = 'No Python traceback found (symbols might be missing)!'
+
+    assert_backtrace(code, 'builtin_abs', backtrace, no_symbols=True)
+
+
+def test_no_backtrace():
+    code = '''
+def f():
+    abs(1)
+
+f()
+'''.lstrip()
+
+    backtrace = 'No Python traceback found (symbols might be missing)!'
+
+    assert_backtrace(code, 'breakpoint_does_not_exist', backtrace)


### PR DESCRIPTION
I admit that the symbol stripping is hackish, but it works. Also, I currently cannot get Python 3.7 to work (even without this patch, seems some issue with debug symbols in the images).

Fixes #13