### PR TITLE
Fix tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: python
 
 matrix:
   include:
-    - name: "Python 3.4"
-      env: PY_VERSION=py34
     - name: "Python 3.5"
       env: PY_VERSION=py35
     - name: "Python 3.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG PY_VERSION=latest
 FROM python:${PY_VERSION}
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-8 main" >> /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y lldb-8 && \
     ln -s /usr/bin/lldb-8 /usr/bin/lldb && \

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@ PY_VERSION := latest
 build-image:
 	docker build -t cpython-lldb:$(PY_VERSION) --build-arg PY_VERSION=$(PY_VERSION) .
 
-build-image-py34: PY_VERSION=3.4
-build-image-py34: build-image
-
 build-image-py35: PY_VERSION=3.5
 build-image-py35: build-image
 
@@ -22,9 +19,6 @@ test: build-image
 		-e PYTHONHASHSEED=1 \
 		cpython-lldb:$(PY_VERSION) \
 		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -vv tests/"
-
-test-py34: PY_VERSION=3.4
-test-py34: test
 
 test-py35: PY_VERSION=3.5
 test-py35: test

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ one might still prefer to use LLDB as a debugger, e.g. on Mac OS.
 Features
 ========
 
-`cpython_lldb` currently targets (== is tested on) CPython 3.4+ and supports
+`cpython_lldb` currently targets (== is tested on) CPython 3.5+ and supports
  the following features:
 
 * pretty-priting of built-in types (int, bool, float, bytes, str, none, tuple, list, set, dict)
@@ -194,11 +194,10 @@ $ make test
 To run the tests against a specific CPython version do:
 
 ```
-$ make test-py34
+$ make test-pyXX
 ```
 
 Supported versions are:
-* `py34`
 * `py35`
 * `py36`
 * `py37`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ homepage = "https://github.com/malor/cpython-lldb"
 keywords = ["debugging", "lldb", "cpython"]
 
 [tool.poetry.dependencies]
-python = "~2.7 || ^3.4"
+python = "~2.7 || ^3.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.4.0"


### PR DESCRIPTION
1. Drop CPython 3.4 support. CPython 3.4 reached its end-of-life in March 2019.
2. Use LLDB built for Debian Buster. DockerHub Python images switched to Debian Buster, so we need to use the corresponding LLDB built, otherwise it won't install due to unresolved dependencies.
3. Add heuristics for discovering location of `PyFrameObject`s when aggressive optimizations are enabled. This is needed to make tests pass after DockerHub Python images enabled Profile Guided Optimization.

Fixes issue #15