### PR TITLE
Use lldb-7 in tests to fix Travis CI builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ ARG PY_VERSION=latest
 FROM python:${PY_VERSION}
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-8 main" >> /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-7 main" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y lldb-8 && \
-    ln -s /usr/bin/lldb-8 /usr/bin/lldb && \
+    apt-get install -y lldb-7 && \
+    ln -s /usr/bin/lldb-7 /usr/bin/lldb && \
     mkdir -p /root/.lldb/cpython-lldb
 
 RUN python -m pip install "poetry>=0.12,<0.13"


### PR DESCRIPTION
lldb-8 comes with broken Python scripting, and lldb-9 can't be
installed due to a broken dependency, so we need to temporarily
switch back to lldb-7 to fix the Travis CI builds on master.

Fixes #17