### PR TITLE
Run tests on CPython 3.8 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: PY_VERSION=py36
     - name: "Python 3.7"
       env: PY_VERSION=py37
+    - name: "Python 3.8"
+      env: PY_VERSION=py38
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ build-image-py36: build-image
 build-image-py37: PY_VERSION=3.7
 build-image-py37: build-image
 
+build-image-py38: PY_VERSION=3.8
+build-image-py38: build-image
+
 
 test: build-image
 	docker run -t -i --rm \
@@ -28,3 +31,6 @@ test-py36: test
 
 test-py37: PY_VERSION=3.7
 test-py37: test
+
+test-py38: PY_VERSION=3.8
+test-py38: test

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Supported versions are:
 * `py35`
 * `py36`
 * `py37`
+* `py38`
 
 
 Contributors


### PR DESCRIPTION
CPython 3.8 has been released, so let's make sure it's tested too.

Either due to LTO optimizations enabled, or due to the new fast calling protocol (PEP 590) implemented in CPython 3.8, we can no longer get a proper representation of builtin_id() frame in LLDB,
that breaks the pretty-printer tests. To fix the tests, we can use the fact that according to the rules of AMD64 calling convention the argument of builtin_id() is passed in the CPU register RSI.