### PR TITLE
Implement a command for listing of the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ Features
 
 * pretty-priting of built-in types (int, bool, float, bytes, str, none, tuple, list, set, dict)
 * printing of Python-level stack traces
+* listing of the source code
 
 TODO:
 
+* walking up and down the Python call stack
 * stack traces w/ mixed stacks (e.g. involving calls to clibs)
 * local variables
-* code listing
 
 
 Installation
@@ -85,6 +86,58 @@ Traceback (most recent call last):
     fa()
   File "test.py", line 2, in fa
     abs(1)
+```
+
+Listing of the source code
+--------------------------
+
+Use `py-list` to list the source code of the Python module that is currently
+being executed in the selected thread, e.g.:
+
+```
+(lldb) py-list
+    1    SOME_CONST = 42
+    2
+    3
+    4    def fa():
+   >5        abs(1)
+    6        return 1
+    7
+    8
+    9    def fb():
+   10        1 + 1
+```
+
+The command also accepts optional `start` and `end` arguments that allow to
+list the source code within a specific range of lines, e.g.:
+
+```
+(lldb) py-list 4
+    4    def fa():
+   >5        abs(1)
+    6        return 1
+    7
+    8
+    9    def fb():
+   10        1 + 1
+   11        fa()
+   12
+   13
+   14    def fc():
+```
+
+or:
+
+```
+(lldb) py-list 4 11
+    4    def fa():
+   >5        abs(1)
+    6        return 1
+    7
+    8
+    9    def fb():
+   10        1 + 1
+   11        fa()
 ```
 
 Potential issues and how to solve them

--- a/tests/test_py_list.py
+++ b/tests/test_py_list.py
@@ -1,0 +1,114 @@
+from .conftest import run_lldb
+
+
+CODE = u'''
+SOME_CONST = u'тест'
+
+
+def fa():
+    abs(1)
+    return 1
+
+
+def fb():
+    1 + 1
+    fa()
+
+
+def fc():
+    fb()
+
+
+fc()
+'''.lstrip()
+
+
+def test_default():
+    expected = u'''\
+    1    SOME_CONST = u'тест'
+    2    
+    3    
+    4    def fa():
+   >5        abs(1)
+    6        return 1
+    7    
+    8    
+    9    def fb():
+   10        1 + 1
+'''
+    actual = run_lldb(
+        code=CODE,
+        breakpoint='builtin_abs',
+        command='py-list',
+    )
+
+    assert actual == expected
+
+
+def test_start():
+    expected = u'''\
+    4    def fa():
+   >5        abs(1)
+    6        return 1
+    7    
+    8    
+    9    def fb():
+   10        1 + 1
+   11        fa()
+   12    
+   13    
+   14    def fc():
+'''
+    actual = run_lldb(
+        code=CODE,
+        breakpoint='builtin_abs',
+        command='py-list 4',
+    )
+
+    assert actual == expected
+
+
+def test_start_end():
+    expected = u'''\
+    4    def fa():
+   >5        abs(1)
+    6        return 1
+    7    
+    8    
+    9    def fb():
+   10        1 + 1
+   11        fa()
+'''
+    actual = run_lldb(
+        code=CODE,
+        breakpoint='builtin_abs',
+        command='py-list 4 11',
+    )
+
+    assert actual == expected
+
+
+def test_non_default_encoding():
+    head = u'# coding: cp1251'
+    code = (head + '\n\n' + CODE).encode('cp1251')
+
+    expected = u'''\
+    2    
+    3    SOME_CONST = u'тест'
+    4    
+    5    
+    6    def fa():
+   >7        abs(1)
+    8        return 1
+    9    
+   10    
+   11    def fb():
+   12        1 + 1
+'''
+    actual = run_lldb(
+        code=code,
+        breakpoint='builtin_abs',
+        command='py-list',
+    )
+
+    assert actual == expected


### PR DESCRIPTION
With a caveat that at the moment it's only possible to list the
source code of the Python module being executed in the most recent
Python frame. This will be fixed when we add support for walking up
and down the Python call stack.

Small fixes for Python 3 compatibility (i.e. when LLDB is linked
against Python 3 libpython).