### PR TITLE
Add support for CPython 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ jobs:
       env: PY_VERSION=py37 LLDB_VERSION=lldb7
     - name: "Python 3.8 @ LLDB 7"
       env: PY_VERSION=py38 LLDB_VERSION=lldb7
+    - name: "Python 3.9 @ LLDB 7"
+      env: PY_VERSION=py39 LLDB_VERSION=lldb7
 
     - name: "Python 3.5 @ LLDB 9"
       env: PY_VERSION=py35 LLDB_VERSION=lldb9
@@ -21,6 +23,8 @@ jobs:
       env: PY_VERSION=py37 LLDB_VERSION=lldb9
     - name: "Python 3.8 @ LLDB 9"
       env: PY_VERSION=py38 LLDB_VERSION=lldb9
+    - name: "Python 3.9 @ LLDB 9"
+      env: PY_VERSION=py39 LLDB_VERSION=lldb9
 
     - name: "Python 3.5 @ LLDB 10"
       env: PY_VERSION=py35 LLDB_VERSION=lldb10
@@ -30,6 +34,8 @@ jobs:
       env: PY_VERSION=py37 LLDB_VERSION=lldb10
     - name: "Python 3.8 @ LLDB 10"
       env: PY_VERSION=py38 LLDB_VERSION=lldb10
+    - name: "Python 3.9 @ LLDB 10"
+      env: PY_VERSION=py39 LLDB_VERSION=lldb10
 
 services:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,9 @@ build-image-py37: build-image
 build-image-py38: PY_VERSION=3.8
 build-image-py38: build-image
 
+build-image-py39: PY_VERSION=3.9
+build-image-py39: build-image
+
 
 test: build-image
 	docker run -t -i --rm \
@@ -37,3 +40,6 @@ test-py37: test
 
 test-py38: PY_VERSION=3.8
 test-py38: test
+
+test-py39: PY_VERSION=3.9
+test-py39: test

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ Supported versions are:
 * `py36`
 * `py37`
 * `py38`
+* `py39`
 
 
 Contributors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import io
 import itertools
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -35,6 +36,12 @@ def extract_command_output(lldb_output, command):
     return u'\n'.join(list(wo_tail)[1:]) + '\n'
 
 
+def normalize_stacktrace(trace):
+    """Replace absolute paths in a stacktrace to make them consistent between runs."""
+
+    return re.sub('File "(.*)test.py"', 'File "test.py"', trace)
+
+
 def run_lldb(code, breakpoint, commands, no_symbols=False):
     commands = list(itertools.chain(*(('-o', command) for command in commands)))
 
@@ -58,7 +65,8 @@ def run_lldb(code, breakpoint, commands, no_symbols=False):
             '-o', 'quit'
         ]
 
-        return subprocess.check_output(args).decode('utf-8')
+        return normalize_stacktrace(
+            subprocess.check_output(args).decode('utf-8'))
     finally:
         os.chdir(old_cwd)
         shutil.rmtree(d, ignore_errors=True)


### PR DESCRIPTION
There were two things that caused the tests to fail on CPython 3.9:

1) PyFrameObject is now an opaque data type that does not expose its
   structure (https://bugs.python.org/issue40421)

2) co_filename is now an absolute path (https://bugs.python.org/issue20443)