### PR TITLE
Add support for pretty-printing of frozensets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Features
 
 `cpython_lldb` targets CPython 3.5+ and supports the following features:
 
-* pretty-priting of built-in types (int, bool, float, bytes, str, none, tuple, list, set, dict)
+* pretty-priting of built-in types (int, bool, float, bytes, str, none, tuple, list, set, frozenset, dict)
 * printing of Python-level stack traces
 * printing of local variables
 * listing the source code

--- a/cpython_lldb.py
+++ b/cpython_lldb.py
@@ -255,9 +255,7 @@ class PyTupleObject(_PySequence, PyObject):
         return self.target.FindFirstType('PyTupleObject')
 
 
-class PySetObject(PyObject):
-
-    typename = 'set'
+class _PySetObject(object):
 
     @property
     def value(self):
@@ -281,6 +279,20 @@ class PySetObject(PyObject):
                 rv.add(PyObject.from_value(key))
 
         return rv
+
+
+class PySetObject(_PySetObject, PyObject):
+
+    typename = 'set'
+
+
+class PyFrozenSetObject(_PySetObject, PyObject):
+
+    typename = 'frozenset'
+
+    @property
+    def value(self):
+        return frozenset(super(PyFrozenSetObject, self).value)
 
 
 class PyDictObject(PyObject):

--- a/tests/test_pretty_printer.py
+++ b/tests/test_pretty_printer.py
@@ -49,7 +49,7 @@ def assert_lldb_repr(value, expected, code_value=None):
     match = lldb_repr_from_frame(value_repr) or lldb_repr_from_register(value_repr)
     assert match is not None
 
-    if isinstance(value, (set, dict)):
+    if isinstance(value, (set, frozenset, dict)):
         # sets and dicts can have different order of keys depending on
         # CPython version, so we evaluate the representation and compare
         # it to the expected value
@@ -124,6 +124,14 @@ def test_set():
                      r'set\(\[False, 1, 3.14159, None, u\'hello\'\]\)')
     assert_lldb_repr(set(range(16)),
                      r'set\(\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15\]\)')
+
+def test_frozenset():
+    assert_lldb_repr(frozenset(), r'frozenset\(\)')
+    assert_lldb_repr(frozenset({1, 2, 3}), r'frozenset\(\{1, 2, 3\}\)')
+    assert_lldb_repr(frozenset({1, 3.14159, u'hello', False, None}),
+                     r'frozenset\(\[False, 1, 3.14159, None, u\'hello\'\]\)')
+    assert_lldb_repr(frozenset(range(16)),
+                     r'frozenset\(\{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15\}\)')
 
 def test_dict():
     assert_lldb_repr({}, '{}')


### PR DESCRIPTION
frozenset and set use the same implementation internally, so we just
need to plumb through a different tp_name value.