### PR TITLE
Run tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test: build-image
 		--security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
 		-e PYTHONHASHSEED=1 \
 		cpython-lldb:$(DOCKER_IMAGE_TAG) \
-		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -vv tests/"
+		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -n 4 -vv tests/ -m 'not serial' && poetry run pytest -n 0 -vv tests/ -m 'serial'"
 
 test-py35: PY_VERSION=3.5
 test-py35: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,4 @@ six = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^4.4.0"
+pytest-xdist = "^1.34.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,7 @@ def run_lldb(code, breakpoint, commands, no_symbols=False):
 
     old_cwd = os.getcwd()
     d = tempfile.mkdtemp()
+    os.chdir(d)
     try:
         with io.open('test.py', 'wb') as fp:
             if isinstance(code, str):

--- a/tests/test_py_bt.py
+++ b/tests/test_py_bt.py
@@ -107,6 +107,7 @@ Traceback (most recent call last):
     assert actual == backtrace
 
 
+@pytest.mark.serial  # strip_symbols does not play nicely with other tests when run in parallel
 @pytest.mark.usefixtures('strip_symbols')
 def test_without_symbols():
     code = '''


### PR DESCRIPTION
Tests are rather slow now. We can look into reducing the number of
times LLDB is started, but the simplest optimization can be running
the tests in parallel by the means of pytest-xdist.

Two minor complications that had to be resolved:

1) a temporary directory was created for each test, but chdir() was
never executed. Fix that.

2) strip_symbols temporary modifies the Python binary in-place, which
obviously does not play nicely with other tests when they are run
in parallel. Work around that by running the single test we use this
fixture in separately