### PR TITLE
Test pretty-printing of CPython structs (PyLongObject, PyDictObject, etc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 __pycache__
 *.pyc
 *.pyo
+build/
+dist/
+tests/test_extension/build/
+tests/test_extension/dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,4 @@ six = "^1.0.0"
 [tool.poetry.dev-dependencies]
 pytest = "^4.4.0"
 pytest-xdist = "^1.34.0"
+test_extension = { path = "tests/test_extension/" }

--- a/tests/test_extension/build.py
+++ b/tests/test_extension/build.py
@@ -1,0 +1,35 @@
+from distutils.core import Extension
+from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
+from distutils.command.build_ext import build_ext
+
+
+ext_modules = [
+    Extension('test_extension._test_extension',
+              sources=['test_extension/test_extension.c'],
+              extra_compile_args=['-g']),
+]
+
+
+class BuildFailed(Exception):
+    pass
+
+
+class ExtBuilder(build_ext):
+
+    def run(self):
+        try:
+            build_ext.run(self)
+        except (DistutilsPlatformError, FileNotFoundError):
+            print('Could not compile C extension.')
+
+    def build_extension(self, ext):
+        try:
+            build_ext.build_extension(self, ext)
+        except (CCompilerError, DistutilsExecError, DistutilsPlatformError, ValueError):
+            print('Could not compile C extension.')
+
+
+def build(setup_kwargs):
+    setup_kwargs.update(
+        {'ext_modules': ext_modules, 'cmdclass': {'build_ext': ExtBuilder}}
+    )

--- a/tests/test_extension/pyproject.toml
+++ b/tests/test_extension/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.poetry]
+name = "test_extension"
+version = "0.1.0"
+description = "A dummy CPython Extension for cpython_lldb tests"
+authors = ["Roman Podoliaka <roman.podoliaka@gmail.com>"]
+build = "build.py"
+
+[tool.poetry.dependencies]
+python = "*"

--- a/tests/test_extension/test_extension/__init__.py
+++ b/tests/test_extension/test_extension/__init__.py
@@ -1,0 +1,1 @@
+from ._test_extension import *

--- a/tests/test_extension/test_extension/test_extension.c
+++ b/tests/test_extension/test_extension/test_extension.c
@@ -1,0 +1,50 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+static PyObject* spam(PyObject* self, PyObject* args) {
+    PyLongObject* local_long = (PyLongObject*) Py_BuildValue("l", 17);
+    PyFloatObject* local_float = (PyFloatObject*) Py_BuildValue("f", 0.0);
+    PyBytesObject* local_bytes = (PyBytesObject*) Py_BuildValue("y", "eggs");
+    PyUnicodeObject* local_unicode = (PyUnicodeObject*) Py_BuildValue("s", "hello");
+    PyListObject* local_list = (PyListObject*) Py_BuildValue("[lll]", 17, 18, 19);
+    PyTupleObject* local_tuple = (PyTupleObject*) Py_BuildValue("(lll)", 24, 23, 22);
+    PyDictObject* local_dict = (PyDictObject*) Py_BuildValue("{s:l}", "foo", 42);
+
+    PyObject* builtins = PyEval_GetBuiltins();
+    PyObject* abs = PyDict_GetItemString(builtins, "abs");
+    PyObject* argslist = Py_BuildValue("(l)", 42);
+    if (argslist == NULL)
+        return NULL;
+    PyObject* result = PyObject_CallObject(abs, argslist);
+    if (result == NULL)
+        return NULL;
+
+    Py_DECREF(result);
+    Py_DECREF(argslist);
+    Py_DECREF(local_long);
+    Py_DECREF(local_float);
+    Py_DECREF(local_bytes);
+    Py_DECREF(local_unicode);
+    Py_DECREF(local_list);
+    Py_DECREF(local_tuple);
+    Py_DECREF(local_dict);
+
+    return Py_None;
+}
+
+static PyMethodDef methods[] = {
+    { "spam", spam, METH_NOARGS, "Test Extension Function" },
+    { NULL, NULL, 0, NULL }
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "test_extension",
+    "Test CPython Extension Module",
+    -1,
+    methods
+};
+
+PyMODINIT_FUNC PyInit__test_extension(void) {
+    return PyModule_Create(&module);
+}


### PR DESCRIPTION
Add a C extension that makes use of CPython structs directly instead of referencing them via PyObject* pointers. This should also allow us to add tests for issue #38.