### PR TITLE
Set up a release process via GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Build and Release
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+      - "*"
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install poetry
+
+      - name: Build artifacts
+        run: |
+          poetry version $(git describe --tags --abbrev=0)
+          poetry build
+
+      - id: release_params
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+            echo "::set-output name=prerelease::false"
+            echo "::set-output name=release_tag::${GITHUB_REF#refs/tags/}"
+            echo "::set-output name=title::${GITHUB_REF#refs/tags/}"
+          else
+            echo "::set-output name=prerelease::true"
+            echo "::set-output name=release_tag::latest"
+            echo "::set-output name=title::Development Build"
+          fi
+
+      - id: create_release
+        uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{ steps.release_params.outputs.prerelease }}
+          automatic_release_tag: ${{ steps.release_params.outputs.release_tag }}
+          title: ${{ steps.release_params.outputs.title }}
+          files: |
+            - dist/*.whl
+
+      - name: Publish to PyPI (only if it's a final release)
+        if: ${{ !steps.release_params.outputs.prerelease }}
+        run: |
+          poetry publish --username ${{ secrets.PYPI_USERNAME }} --password ${{ secrets.PYPI_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ ENV PYTHONPATH /usr/lib/llvm-${LLDB_VERSION}/lib/python3/dist-packages
 
 COPY . /root/.lldb/cpython-lldb
 RUN cd /root/.lldb/cpython-lldb && \
-    python -m pip install "poetry>=0.12,<0.13" && \
+    python -m pip install poetry && \
+    poetry version $(git describe --tags --abbrev=0) && \
     poetry install && poetry build -n -f wheel && \
     mkdir -p ~/.lldb/cpython_lldb/site-packages && \
     python -m pip install --target ~/.lldb/cpython_lldb/site-packages dist/*.whl && rm -rf dist && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cpython-lldb"
-version = "0.2.0"
+version = "0.0.0"
 description = "LLDB script for debugging of CPython processes"
 license = "MIT"
 


### PR DESCRIPTION
Pushing a tag will now automatically start the release workflow, which:

* bumps the version in pyproject.toml
* creates a new release in GitHub
* creates release artifacts
* uploads them to PyPI and GitHub