### PR TITLE
testing: reduce the test run time by not restarting LLDB

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,5 +35,7 @@ jobs:
         env:
           PY_VERSION: ${{ matrix.py_version }}
           LLDB_VERSION: ${{ matrix.lldb_version }}
+          # runner only has a single CPU core, so there is no sense in trying to put more load on it
+          CONCURRENCY: 2
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PY_VERSION ?= 3.10
 LLDB_VERSION ?= 11
 DOCKER_IMAGE_TAG = $(PY_VERSION)-lldb$(LLDB_VERSION)
+CONCURRENCY ?= 8
 
 # older LLVM versions are not packaged for Debian Bullseye, which is the new stable
 # used in Python Docker images. We can fall back to Buster images for testing those
@@ -23,4 +24,4 @@ test: build-image
 		--security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
 		-e PYTHONHASHSEED=1 \
 		cpython-lldb:$(DOCKER_IMAGE_TAG) \
-		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -n 4 -vv tests/ -m 'not serial' && poetry run pytest -n 0 -vv tests/ -m 'serial'"
+		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -n $(CONCURRENCY) -vv tests/"

--- a/cpython_lldb.py
+++ b/cpython_lldb.py
@@ -755,7 +755,11 @@ class Command(object):
             args = self.argument_parser.parse_args(shlex.split(command))
             self.execute(debugger, args, result)
         except Exception as e:
-            result.SetError(u'Failed to execute command `{}`: {}'.format(self.command, e))
+            msg = u'Failed to execute command `{}`: {}'.format(self.command, e)
+            if six.PY2:
+                msg = msg.encode('utf-8')
+
+            result.SetError(msg)
 
     @property
     def argument_parser(self):

--- a/poetry.lock
+++ b/poetry.lock
@@ -176,6 +176,17 @@ scandir = {version = "*", markers = "python_version < \"3.5\""}
 six = "*"
 
 [[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
 name = "pluggy"
 version = "0.13.1"
 description = "plugin and hook calling mechanisms for python"
@@ -205,12 +216,20 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pyparsing"
@@ -403,7 +422,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "~2.7 || ^3.5"
-content-hash = "cbd9e52fa903d44a24236abc13b427e5f91d9d55d6e7b7939e52b619120b4fd7"
+content-hash = "ca948bb4252f449dafe109fcc188f65f92947bdbd3767a72ad4bec0bf547bbd1"
 
 [metadata.files]
 atomicwrites = [
@@ -465,15 +484,23 @@ pathlib2 = [
     {file = "pathlib2-2.3.6-py2.py3-none-any.whl", hash = "sha256:3a130b266b3a36134dcc79c17b3c7ac9634f083825ca6ea9d8f557ee6195c9c8"},
     {file = "pathlib2-2.3.6.tar.gz", hash = "sha256:7d8bcb5555003cdf4a8d2872c538faa3a0f5d20630cb360e518ca3b981795e5f"},
 ]
+pexpect = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+ptyprocess = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
+]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ python = "~2.7 || ^3.5"
 six = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
+pexpect = "^4.8.0"
 # we want to specify the depedency on pytest here as well, but that confuses poetry, so we rely
 # on pytest-xdist to depend on pytest transitively instead
 pytest-xdist = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-    serial: run the tests that can't be executed in parallel.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,39 +1,116 @@
+import contextlib
 import io
-import itertools
-import os
 import re
-import shutil
+import os
 import subprocess
 import sys
-import tempfile
 
+import pexpect
 import pytest
 
 
-@pytest.fixture
-def strip_symbols():
-    executable = sys.executable
+@pytest.fixture(scope='session')
+def lldb_session(tmpdir_factory):
+    """Starts LLDB in the background with Python as the target process.
 
-    libpython = subprocess.check_output("ldd %s | grep libpython | awk '{print $3}'" % (executable), shell=True).decode("utf-8").strip()
-    libpython_backup = libpython + ".backup"
+    LLDB is started via pexpect.spawn; bidirectional communication with the child process is
+    performed via pipes attached to its stdin/stdout/stderr.
+
+    This fixture has the session scope, so that LLDB is only launched once and reused across
+    different tests. That is managed via a separate, function-scoped fixture -- lldb.
+    """
+
+    session = pexpect.spawn(
+        'lldb',
+        args=['-O', 'settings set use-color 0', sys.executable],
+        cwd=tmpdir_factory.mktemp('lldb').strpath,
+        encoding='utf-8',
+        timeout=6,
+        maxread=65536,
+        env={
+            'PYTHONPATH': os.environ.get('PYTHONPATH', ''),
+            'PYTHONHASHSEED': os.environ.get('PYTHONHASHSEED', '1'),
+            'LANG': os.environ.get('LANG'),
+        },
+    )
+    session.expect('Current executable set to')
+
+    yield session
+
+
+@pytest.fixture(scope='session')
+def lldb_no_symbols_session(tmpdir_factory):
+    """Starts LLDB in the background with Python as the target process.
+
+    Same as lldb_session, but also creates a copy of libpython w/o debugging symbols and updates
+    LD_LIBRARY_PATH to point to it.
+    """
+
+    tmpdir = tmpdir_factory.mktemp('lldb')
+    with tmpdir.as_cwd():
+        libpython = subprocess.check_output("ldd %s | grep libpython | awk '{print $3}'" % (sys.executable), shell=True).decode("utf-8").strip()
+        libpython_copy = tmpdir.join(os.path.basename(libpython)).strpath
+        subprocess.check_call(['cp',  libpython, libpython_copy])
+        subprocess.check_call(['strip', '-S', libpython_copy])
+
+    session = pexpect.spawn(
+        'lldb',
+        args=['-O', 'settings set use-color 0', sys.executable],
+        cwd=tmpdir.strpath,
+        encoding='utf-8',
+        timeout=6,
+        maxread=65536,
+        env={
+            'PYTHONPATH': os.environ.get('PYTHONPATH', ''),
+            'PYTHONHASHSEED': os.environ.get('PYTHONHASHSEED', '1'),
+            'LD_LIBRARY_PATH': '.',
+            'LANG': os.environ.get('LANG'),
+        },
+    )
+    session.expect('Current executable set to')
+
+    yield session
+
+
+@contextlib.contextmanager
+def _lldb_manager(lldb_session):
+    prev_cwd = os.getcwd()
+    os.chdir(lldb_session.cwd)
 
     try:
-        subprocess.check_call("cp %s %s" % (libpython, libpython_backup), shell=True)
-        subprocess.check_call("strip -S %s" % (libpython), shell=True)
-        yield
-    except Exception:
-        pytest.skip("Cannot strip symbols")
+        yield lldb_session
+    finally:
+        os.chdir(prev_cwd)
 
-    subprocess.check_call("cp %s %s" % (libpython_backup, libpython), shell=True)
+        lldb_session.sendline('kill')
+        lldb_session.expect(re.compile(r'Process \d+ exited'))
+        lldb_session.expect(re.escape('(lldb) '))
+        lldb_session.sendline('breakpoint delete --force')
+        lldb_session.expect('All breakpoints removed. ')
+        lldb_session.expect(re.escape('(lldb) '))
 
 
-def extract_command_output(lldb_output, command):
-    wo_head = itertools.dropwhile(lambda line: line != '(lldb) {}'.format(command),
-                                  lldb_output.splitlines())
-    wo_tail = itertools.takewhile(lambda line: line != '(lldb) quit',
-                                  wo_head)
+@pytest.fixture
+def lldb(lldb_session):
+    """Re-usable LLDB session.
 
-    return u'\n'.join(list(wo_tail)[1:]) + '\n'
+    Returns a context manager that can be used to retrieve a pexpect.spawn handle controlling an
+    LLDB instance running in the background. The context manager will automatically clean up the
+    state (such as breakpoints) and terminate the Python process under debug, so that another
+    session can be created w/o restarting LLDB.
+
+    As a side effect, the context manager will temporarily change the current working directory
+    created for this LLDB instance.
+    """
+
+    return lambda: _lldb_manager(lldb_session)
+
+
+@pytest.fixture
+def lldb_no_symbols(lldb_no_symbols_session):
+    """Same as lldb, but uses a copy of libpython with stripped debugging symbols."""
+
+    return lambda: _lldb_manager(lldb_no_symbols_session)
 
 
 def normalize_stacktrace(trace):
@@ -42,32 +119,34 @@ def normalize_stacktrace(trace):
     return re.sub('File "(.*)test.py"', 'File "test.py"', trace)
 
 
-def run_lldb(code, breakpoint, commands, no_symbols=False):
-    commands = list(itertools.chain(*(('-o', command) for command in commands)))
+def run_lldb(lldb_manager, code, breakpoint, commands):
+    """Run arbitrary LLDB commands after the given Python snippets hits a specified breakpoint.
 
-    old_cwd = os.getcwd()
-    d = tempfile.mkdtemp()
-    os.chdir(d)
-    try:
+    Returns a list that contains an output each command has produced. As a side effect, absolute
+    paths in the stacktraces are automatically truncated to the final (i.e. file name) part.
+    """
+
+    outputs = []
+
+    with lldb_manager() as lldb:
         with io.open('test.py', 'wb') as fp:
             if isinstance(code, str):
                 code = code.encode('utf-8')
 
             fp.write(code)
 
-        args = ['lldb']
-        if no_symbols:
-            args += ['-o', 'settings set symbols.enable-external-lookup false']
-        args += [
-            sys.executable,
-            '-o', 'breakpoint set -r %s' % (breakpoint),
-            '-o', 'run "test.py"',
-            *commands,
-            '-o', 'quit'
-        ]
+        lldb.sendline('breakpoint set -r %s' % breakpoint)
+        lldb.expect(r'Breakpoint \d+')
+        lldb.expect(re.escape('(lldb) '))
+        lldb.sendline('run test.py')
+        lldb.expect(r'Process \d+ stopped')
+        lldb.expect(re.escape('(lldb) '))
 
-        return normalize_stacktrace(
-            subprocess.check_output(args).decode('utf-8'))
-    finally:
-        os.chdir(old_cwd)
-        shutil.rmtree(d, ignore_errors=True)
+        for command in commands:
+            lldb.sendline(command)
+            lldb.expect(re.escape('%s\r\n' % command))
+            lldb.expect(re.escape('(lldb) '))
+
+            outputs.append(normalize_stacktrace(lldb.before.replace('\r\n', '\n')))
+
+    return outputs

--- a/tests/test_pretty_printer.py
+++ b/tests/test_pretty_printer.py
@@ -1,19 +1,20 @@
 import collections
 import re
 
-from .conftest import run_lldb, extract_command_output
+from .conftest import run_lldb
 
 
-def lldb_repr_from_frame(value):
+def lldb_repr_from_frame(lldb_manager, value):
     # set a breakpoint in the implementation of the builtin function id(), that
     # is conveniently called with a single argument (v), which representation
     # we are trying to scrape from the LLDB output. When the breakpoint is hit,
     # the argument value will be pretty-printed by `frame info` command
     response = run_lldb(
+        lldb_manager,
         code='from collections import *; from six.moves import *; id(%s)' % value,
         breakpoint='builtin_id',
         commands=['frame info'],
-    )
+    )[-1]
 
     actual = [
         line
@@ -25,16 +26,17 @@ def lldb_repr_from_frame(value):
     return match
 
 
-def lldb_repr_from_register(value):
-    # same as lldb_repr_from_frame(), but also works in cases when the CPython
+def lldb_repr_from_register(lldb_manager, value):
+        # same as lldb_repr_from_frame(), but also works in cases when the CPython
     # build does not provide information on the arguments of builtin_id():
     # here we use the fact that the value of `v` argument is passed in the
     # CPU register RSI according to the rules of AMD64 calling convention
     response = run_lldb(
+        lldb_manager,
         code='from collections import *; from six.moves import *; id(%s)' % value,
         breakpoint='builtin_id',
         commands=['print (PyObject*) $rsi'],
-    )
+    )[-1]
     actual = [
         line.strip()
         for line in response.splitlines()
@@ -45,9 +47,9 @@ def lldb_repr_from_register(value):
     return match
 
 
-def assert_lldb_repr(value, expected, code_value=None):
+def assert_lldb_repr(lldb_manager, value, expected, code_value=None):
     value_repr = code_value or repr(value)
-    match = lldb_repr_from_frame(value_repr) or lldb_repr_from_register(value_repr)
+    match = lldb_repr_from_frame(lldb_manager, value_repr) or lldb_repr_from_register(lldb_manager, value_repr)
     assert match is not None
 
     if isinstance(value, (set, frozenset, dict)):
@@ -66,176 +68,178 @@ def assert_lldb_repr(value, expected, code_value=None):
         assert re.match(expected, match.group(1)), "Expected: %s\nActual: %s" % (expected, match.group(1))
 
 
-def test_int():
-    assert_lldb_repr(-10, '-10')
-    assert_lldb_repr(0, '0')
-    assert_lldb_repr(42, '42')
-    assert_lldb_repr(-2 ** 32, '-4294967296')
-    assert_lldb_repr(2 ** 32, '4294967296')
-    assert_lldb_repr(-2 ** 64, '-18446744073709551616')
-    assert_lldb_repr(2 ** 64, '18446744073709551616')
+def test_int(lldb):
+    assert_lldb_repr(lldb, -10, '-10')
+    assert_lldb_repr(lldb, 0, '0')
+    assert_lldb_repr(lldb, 42, '42')
+    assert_lldb_repr(lldb, -2 ** 32, '-4294967296')
+    assert_lldb_repr(lldb, 2 ** 32, '4294967296')
+    assert_lldb_repr(lldb, -2 ** 64, '-18446744073709551616')
+    assert_lldb_repr(lldb, 2 ** 64, '18446744073709551616')
 
 
-def test_bool():
-    assert_lldb_repr(True, 'True')
-    assert_lldb_repr(False, 'False')
+def test_bool(lldb):
+    assert_lldb_repr(lldb, True, 'True')
+    assert_lldb_repr(lldb, False, 'False')
 
 
-def test_none():
-    assert_lldb_repr(None, 'None')
+def test_none(lldb):
+    assert_lldb_repr(lldb, None, 'None')
 
 
-def test_float():
-    assert_lldb_repr(0.0, r'0\.0')
-    assert_lldb_repr(42.42, r'42\.42')
-    assert_lldb_repr(-42.42, r'-42\.42')
+def test_float(lldb):
+    assert_lldb_repr(lldb, 0.0, r'0\.0')
+    assert_lldb_repr(lldb, 42.42, r'42\.42')
+    assert_lldb_repr(lldb, -42.42, r'-42\.42')
 
 
-def test_bytes():
-    assert_lldb_repr(b'', "b?''")
-    assert_lldb_repr(b'hello', "b?'hello'")
-    assert_lldb_repr(b'\x42\x42', "b?'BB'")
-    assert_lldb_repr(b'\x42\x00\x42', r"b?'B\\x00B'")
-    assert_lldb_repr(b'\x00\x00\x00\x00', r"b?'\\x00\\x00\\x00\\x00'")
+def test_bytes(lldb):
+    assert_lldb_repr(lldb, b'', "b?''")
+    assert_lldb_repr(lldb, b'hello', "b?'hello'")
+    assert_lldb_repr(lldb, b'\x42\x42', "b?'BB'")
+    assert_lldb_repr(lldb, b'\x42\x00\x42', r"b?'B\\x00B'")
+    assert_lldb_repr(lldb, b'\x00\x00\x00\x00', r"b?'\\x00\\x00\\x00\\x00'")
 
 
-def test_str():
-    assert_lldb_repr('', "u?''")
-    assert_lldb_repr('hello', "u?'hello'")
-    assert_lldb_repr(u'привет',
+def test_str(lldb):
+    assert_lldb_repr(lldb, '', "u?''")
+    assert_lldb_repr(lldb, 'hello', "u?'hello'")
+    assert_lldb_repr(lldb, u'привет',
                      "(u'\\\\u043f\\\\u0440\\\\u0438\\\\u0432\\\\u0435\\\\u0442')|('привет')")
-    assert_lldb_repr(u'𐅐𐅀𐅰',
+    assert_lldb_repr(lldb, u'𐅐𐅀𐅰',
                      "(u'\\\\U00010150\\\\U00010140\\\\U00010170')|('𐅐𐅀𐅰')")
-    assert_lldb_repr(u'æ', "(u'\\\\xe6')|('æ')")
+    assert_lldb_repr(lldb, u'æ', "(u'\\\\xe6')|('æ')")
 
 
-def test_list():
-    assert_lldb_repr([], r'\[\]')
-    assert_lldb_repr([1, 2, 3], r'\[1, 2, 3\]')
-    assert_lldb_repr([1, 3.14159, u'hello', False, None],
+def test_list(lldb):
+    assert_lldb_repr(lldb, [], r'\[\]')
+    assert_lldb_repr(lldb, [1, 2, 3], r'\[1, 2, 3\]')
+    assert_lldb_repr(lldb, [1, 3.14159, u'hello', False, None],
                      r'\[1, 3.14159, u?\'hello\', False, None\]')
 
 
-def test_tuple():
-    assert_lldb_repr((), r'\(\)')
-    assert_lldb_repr((1, 2, 3), r'\(1, 2, 3\)')
-    assert_lldb_repr((1, 3.14159, u'hello', False, None),
+def test_tuple(lldb):
+    assert_lldb_repr(lldb, (), r'\(\)')
+    assert_lldb_repr(lldb, (1, 2, 3), r'\(1, 2, 3\)')
+    assert_lldb_repr(lldb, (1, 3.14159, u'hello', False, None),
                      r'\(1, 3.14159, u?\'hello\', False, None\)')
 
-def test_set():
-    assert_lldb_repr(set(), r'set\(\[\]\)')
-    assert_lldb_repr(set([1, 2, 3]), r'set\(\[1, 2, 3\]\)')
-    assert_lldb_repr(set([1, 3.14159, u'hello', False, None]),
+def test_set(lldb):
+    assert_lldb_repr(lldb, set(), r'set\(\[\]\)')
+    assert_lldb_repr(lldb, set([1, 2, 3]), r'set\(\[1, 2, 3\]\)')
+    assert_lldb_repr(lldb, set([1, 3.14159, u'hello', False, None]),
                      r'set\(\[False, 1, 3.14159, None, u\'hello\'\]\)')
-    assert_lldb_repr(set(range(16)),
+    assert_lldb_repr(lldb, set(range(16)),
                      r'set\(\[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15\]\)')
 
-def test_frozenset():
-    assert_lldb_repr(frozenset(), r'frozenset\(\)')
-    assert_lldb_repr(frozenset({1, 2, 3}), r'frozenset\(\{1, 2, 3\}\)')
-    assert_lldb_repr(frozenset({1, 3.14159, u'hello', False, None}),
+def test_frozenset(lldb):
+    assert_lldb_repr(lldb, frozenset(), r'frozenset\(\)')
+    assert_lldb_repr(lldb, frozenset({1, 2, 3}), r'frozenset\(\{1, 2, 3\}\)')
+    assert_lldb_repr(lldb, frozenset({1, 3.14159, u'hello', False, None}),
                      r'frozenset\(\[False, 1, 3.14159, None, u\'hello\'\]\)')
-    assert_lldb_repr(frozenset(range(16)),
+    assert_lldb_repr(lldb, frozenset(range(16)),
                      r'frozenset\(\{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15\}\)')
 
-def test_dict():
-    assert_lldb_repr({}, '{}')
-    assert_lldb_repr({1: 2, 3: 4}, '{1: 2, 3: 4}')
-    assert_lldb_repr({1: 2, 'a': 'b'}, "{1: 2, u'a': u'b'}")
-    assert_lldb_repr({i: i for i in range(16)},
+def test_dict(lldb):
+    assert_lldb_repr(lldb, {}, '{}')
+    assert_lldb_repr(lldb, {1: 2, 3: 4}, '{1: 2, 3: 4}')
+    assert_lldb_repr(lldb, {1: 2, 'a': 'b'}, "{1: 2, u'a': u'b'}")
+    assert_lldb_repr(lldb, {i: i for i in range(16)},
                      ('{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8,'
                       ' 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15}'))
 
-def test_defaultdict():
-    assert_lldb_repr(collections.defaultdict(int), '{}', 'defaultdict(int)')
-    assert_lldb_repr(collections.defaultdict(int, {1: 2, 3: 4}),
+def test_defaultdict(lldb):
+    assert_lldb_repr(lldb, collections.defaultdict(int), '{}', 'defaultdict(int)')
+    assert_lldb_repr(lldb, collections.defaultdict(int, {1: 2, 3: 4}),
                      '{1: 2, 3: 4}',
                      'defaultdict(int, {1: 2, 3: 4})')
-    assert_lldb_repr(collections.defaultdict(int, {1: 2, 'a': 'b'}),
+    assert_lldb_repr(lldb, collections.defaultdict(int, {1: 2, 'a': 'b'}),
                      "{1: 2, u'a': u'b'}",
                      "defaultdict(int, {1: 2, 'a': 'b'})")
-    assert_lldb_repr(collections.defaultdict(int, {i: i for i in range(16)}),
+    assert_lldb_repr(lldb, collections.defaultdict(int, {i: i for i in range(16)}),
                      ('{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8,'
                       ' 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15}'),
                      'defaultdict(int, {i: i for i in range(16)})')
 
 
-def test_ordered_dict():
-    assert_lldb_repr(collections.OrderedDict(), 'OrderedDict()')
-    assert_lldb_repr(collections.OrderedDict([(1, 2), (3, 4)]),
+def test_ordered_dict(lldb):
+    assert_lldb_repr(lldb, collections.OrderedDict(), 'OrderedDict()')
+    assert_lldb_repr(lldb, collections.OrderedDict([(1, 2), (3, 4)]),
                      'OrderedDict([(1, 2), (3, 4)])')
-    assert_lldb_repr(collections.OrderedDict([(1, 2), ('a', 'b')]),
+    assert_lldb_repr(lldb, collections.OrderedDict([(1, 2), ('a', 'b')]),
                      "OrderedDict([(1, 2), ('a', 'b')])")
-    assert_lldb_repr(collections.OrderedDict((i, i) for i in range(16)),
+    assert_lldb_repr(lldb, collections.OrderedDict((i, i) for i in range(16)),
                      ('OrderedDict([(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), '
                       '(5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), '
                       '(11, 11), (12, 12), (13, 13), (14, 14), (15, 15)])'))
 
 
-def test_userdict():
-    assert_lldb_repr(collections.UserDict(), '{}', 'UserDict()')
-    assert_lldb_repr(collections.UserDict({1: 2, 3: 4}),
+def test_userdict(lldb):
+    assert_lldb_repr(lldb, collections.UserDict(), '{}', 'UserDict()')
+    assert_lldb_repr(lldb, collections.UserDict({1: 2, 3: 4}),
                      '{1: 2, 3: 4}',
                      'UserDict({1: 2, 3: 4})')
-    assert_lldb_repr(collections.UserDict({1: 2, 'a': 'b'}),
+    assert_lldb_repr(lldb, collections.UserDict({1: 2, 'a': 'b'}),
                      "{1: 2, u?'a': u?'b'}",
                      "UserDict({1: 2, 'a': 'b'})")
-    assert_lldb_repr(collections.UserDict({i: i for i in range(16)}),
+    assert_lldb_repr(lldb, collections.UserDict({i: i for i in range(16)}),
                      ('{0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8,'
                       ' 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15}'),
                      'UserDict({i: i for i in range(16)})')
 
 
-def test_userstring():
-    assert_lldb_repr(collections.UserString(''), "u?''",
+def test_userstring(lldb):
+    assert_lldb_repr(lldb, collections.UserString(''), "u?''",
                      'UserString("")')
-    assert_lldb_repr(collections.UserString('hello'), "u?'hello'",
+    assert_lldb_repr(lldb, collections.UserString('hello'), "u?'hello'",
                      'UserString("hello")')
-    assert_lldb_repr(collections.UserString(u'привет'),
+    assert_lldb_repr(lldb, collections.UserString(u'привет'),
                      "(u'\\\\u043f\\\\u0440\\\\u0438\\\\u0432\\\\u0435\\\\u0442')|('привет')",
                      'UserString(u"привет")')
-    assert_lldb_repr(collections.UserString(u'𐅐𐅀𐅰'),
+    assert_lldb_repr(lldb, collections.UserString(u'𐅐𐅀𐅰'),
                      "(u'\\\\U00010150\\\\U00010140\\\\U00010170')|('𐅐𐅀𐅰')",
                      'UserString(u"𐅐𐅀𐅰")')
-    assert_lldb_repr(collections.UserString(u'æ'),
+    assert_lldb_repr(lldb, collections.UserString(u'æ'),
                      "(u'\\\\xe6')|('æ')",
                      'UserString(u"æ")')
 
 
-def test_userlist():
-    assert_lldb_repr(collections.UserList(), r'\[\]',
+def test_userlist(lldb):
+    assert_lldb_repr(lldb, collections.UserList(), r'\[\]',
                      'UserList()')
-    assert_lldb_repr(collections.UserList([1, 2, 3]), r'\[1, 2, 3\]',
+    assert_lldb_repr(lldb, collections.UserList([1, 2, 3]), r'\[1, 2, 3\]',
                      'UserList([1, 2, 3])')
-    assert_lldb_repr(collections.UserList([1, 3.14159, u'hello', False, None]),
+    assert_lldb_repr(lldb, collections.UserList([1, 3.14159, u'hello', False, None]),
                      r'\[1, 3.14159, u?\'hello\', False, None\]',
                      'UserList([1, 3.14159, u"hello", False, None])')
 
 
-def test_counter():
-    assert_lldb_repr(collections.Counter(), 'Counter()')
-    assert_lldb_repr(collections.Counter({1: 2, 3: 4}),
+def test_counter(lldb):
+    assert_lldb_repr(lldb, collections.Counter(), 'Counter()')
+    assert_lldb_repr(lldb, collections.Counter({1: 2, 3: 4}),
                      'Counter({1: 2, 3: 4})')
-    assert_lldb_repr(collections.Counter({1: 2, 'a': 'b'}),
+    assert_lldb_repr(lldb, collections.Counter({1: 2, 'a': 'b'}),
                      "Counter({1: 2, u'a': u'b'})")
-    assert_lldb_repr(collections.Counter({i: i for i in range(16)}),
+    assert_lldb_repr(lldb, collections.Counter({i: i for i in range(16)}),
                      ('Counter({0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, '
                       '8: 8, 9: 9, 10: 10, 11: 11, 12: 12, 13: 13, 14: 14, 15: 15})'))
 
 
-def test_unsupported():
-    assert_lldb_repr(object(), '(\'0x[0-9a-f]+\')|(\'No value\')', code_value='object()')
+def test_unsupported(lldb):
+    assert_lldb_repr(lldb, object(), '(\'0x[0-9a-f]+\')|(\'No value\')', code_value='object()')
 
 
-def test_locals_c_extension():
+def test_locals_c_extension(lldb):
     code = 'import test_extension; test_extension.spam()'
     response = run_lldb(
+        lldb,
         code=code,
         breakpoint='builtin_abs',
         commands=['bt'],
-    )
-    frame_match = re.search(r'.*frame #(\d+).*_test_extension.*`spam.*',
-                            extract_command_output(response, 'bt'))
+    )[-1]
+    frame_match = re.search(r'.*frame #(\d+).*_test_extension.*`spam.*', response)
+    assert frame_match is not None, 'frame not found'
+
     if frame_match:
         frame_index = int(frame_match.groups()[0])
 
@@ -261,14 +265,15 @@ def test_locals_c_extension():
 '''.rstrip()
 
     response = run_lldb(
+        lldb,
         code=code,
         breakpoint='builtin_abs',
         commands=['up'] * frame_index + ['frame variable'],
-    )
+    )[-1]
     actual = u'\n'.join(
         sorted(
             re.sub(r'(0x[0-9a-f]+ )', '', line)
-            for line in extract_command_output(response, 'frame variable').splitlines()
+            for line in response.splitlines()
             if u'local_' in line
         )
     )

--- a/tests/test_py_list.py
+++ b/tests/test_py_list.py
@@ -1,4 +1,4 @@
-from .conftest import extract_command_output, run_lldb
+from .conftest import run_lldb
 
 
 CODE = u'''
@@ -23,7 +23,7 @@ fc()
 '''.lstrip()
 
 
-def test_default():
+def test_default(lldb):
     expected = u'''\
     1    SOME_CONST = u'тест'
     2    
@@ -35,18 +35,19 @@ def test_default():
     8    
     9    def fb():
    10        1 + 1
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-list'],
-    )
-    actual = extract_command_output(response, 'py-list')
+    )[-1]
+    actual = response.rstrip()
 
     assert actual == expected
 
 
-def test_start():
+def test_start(lldb):
     expected = u'''\
     4    def fa():
    >5        abs(1)
@@ -59,18 +60,19 @@ def test_start():
    12    
    13    
    14    def fc():
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-list 4'],
-    )
-    actual = extract_command_output(response, 'py-list 4')
+    )[-1]
+    actual = response.rstrip()
 
     assert actual == expected
 
 
-def test_start_end():
+def test_start_end(lldb):
     expected = u'''\
     4    def fa():
    >5        abs(1)
@@ -80,18 +82,19 @@ def test_start_end():
     9    def fb():
    10        1 + 1
    11        fa()
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-list 4 11'],
-    )
-    actual = extract_command_output(response, 'py-list 4 11')
+    )[-1]
+    actual = response.rstrip()
 
     assert actual == expected
 
 
-def test_non_default_encoding():
+def test_non_default_encoding(lldb):
     head = u'# coding: cp1251'
     code = (head + '\n\n' + CODE).encode('cp1251')
 
@@ -107,18 +110,19 @@ def test_non_default_encoding():
    10    
    11    def fb():
    12        1 + 1
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=code,
         breakpoint='builtin_abs',
         commands=['py-list'],
-    )
-    actual = extract_command_output(response, 'py-list')
+    )[-1]
+    actual = response.rstrip()
 
     assert actual == expected
 
 
-def test_not_the_most_recent_frame():
+def test_not_the_most_recent_frame(lldb):
     expected = u'''\
     6        return 1
     7    
@@ -131,12 +135,13 @@ def test_not_the_most_recent_frame():
    14    def fc():
    15        fb()
    16    
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-up', 'py-list'],
-    )
-    actual = extract_command_output(response, 'py-list')
+    )[-1]
+    actual = response.rstrip()
 
     assert actual == expected

--- a/tests/test_py_up_down.py
+++ b/tests/test_py_up_down.py
@@ -1,4 +1,4 @@
-from .conftest import extract_command_output, run_lldb
+from .conftest import run_lldb
 
 
 CODE = u'''
@@ -23,66 +23,61 @@ fc()
 '''.lstrip()
 
 
-def test_up_down():
+def test_up_down(lldb):
     expected = u'''\
   File "test.py", line 11, in fb
     fa()
-(lldb) py-up
   File "test.py", line 15, in fc
     fb()
-(lldb) py-up
   File "test.py", line 18, in <module>
     fc()
-(lldb) py-down
   File "test.py", line 15, in fc
     fb()
-(lldb) py-down
   File "test.py", line 11, in fb
     fa()
-(lldb) py-up
   File "test.py", line 15, in fc
     fb()
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-up', 'py-up', 'py-up', 'py-down', 'py-down', 'py-up'],
     )
-    actual = extract_command_output(response, 'py-up')
+    actual = u''.join(response).rstrip()
 
     assert actual == expected
 
 
-def test_newest_frame():
-    expected = u'*** Newest frame\n'
+def test_newest_frame(lldb):
+    expected = u'*** Newest frame'
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-down'],
     )
-    actual = extract_command_output(response, 'py-down')
+    actual = u''.join(response).rstrip()
 
     assert actual == expected
 
 
-def test_oldest_frame():
+def test_oldest_frame(lldb):
     expected = u'''\
   File "test.py", line 11, in fb
     fa()
-(lldb) py-up
   File "test.py", line 15, in fc
     fb()
-(lldb) py-up
   File "test.py", line 18, in <module>
     fc()
-(lldb) py-up
 *** Oldest frame
-'''
+'''.rstrip()
     response = run_lldb(
+        lldb,
         code=CODE,
         breakpoint='builtin_abs',
         commands=['py-up'] * 4,
     )
-    actual = extract_command_output(response, 'py-up')
+    actual = u''.join(response).rstrip()
 
     assert actual == expected


### PR DESCRIPTION
Instead of starting LLDB for each test case, we can start it once in the background and reuse it across all the tests run by a given pytest-xdist process. This requires each test to clean up the breakpoints and restart the process under debug, but overall, it's not too hard. Communication with the LLDB instance happens via pipes attached to its stdin/stdout/stderr and is managed by pexpect.
    
This, combined with the increased concurrency level, allowed to reduce the time it takes to complete a single test run from ~45s to ~24s (on my machine). Unfortunately, that does not translate to a speed up on CI, as the Github Actions runner seem to only have a single CPU core.