### PR TITLE
CI: run the tests daily

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
     ranches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+    # run daily. The exact time does not matter; just try to avoid popular times like midnight
+    - cron: '17 5 * * *'
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Overview
 ========
 
+![build status](https://github.com/malor/cpython-lldb/actions/workflows/tests.yml/badge.svg)
+
 `cpython_lldb` is an LLDB extension for debugging Python programs.
 
 It may be useful for troubleshooting stuck threads and crashes in the interpreter,


### PR DESCRIPTION
This is meant to detect breakages caused by Python Docker image updates.