### PR TITLE
Add auxiliary build targets for debugging failed tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,5 @@ jobs:
         env:
           PY_VERSION: ${{ matrix.py_version }}
           LLDB_VERSION: ${{ matrix.lldb_version }}
-          # runner only has a single CPU core, so there is no sense in trying to put more load on it
-          CONCURRENCY: 2
         run: |
           make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 PY_VERSION ?= 3.10
 LLDB_VERSION ?= 11
 DOCKER_IMAGE_TAG = $(PY_VERSION)-lldb$(LLDB_VERSION)
-CONCURRENCY ?= 8
 
 # older LLVM versions are not packaged for Debian Bullseye, which is the new stable
 # used in Python Docker images. We can fall back to Buster images for testing those
@@ -18,10 +17,29 @@ build-image:
 		--build-arg LLDB_VERSION=$(LLDB_VERSION) \
 		-f Dockerfile .
 
+# Run tests normally. The level of parallelism is set to match the number of CPU threads
 test: build-image
 	docker run \
 		--rm \
 		--security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
 		-e PYTHONHASHSEED=1 \
 		cpython-lldb:$(DOCKER_IMAGE_TAG) \
-		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -n $(CONCURRENCY) -vv tests/"
+		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -n auto -vv tests/"
+
+# Run tests serially and start a pdb session when a test fails
+debug: build-image
+	docker run -t -i \
+		--rm \
+		--security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
+		-e PYTHONHASHSEED=1 \
+		cpython-lldb:$(DOCKER_IMAGE_TAG) \
+		bash -c "cd /root/.lldb/cpython-lldb && poetry run pytest -s -n auto -vv --pdb -x --ff tests/"
+
+# Start a shell in a container with cpython-lldb installed
+shell: build-image
+	docker run -t -i \
+		--rm \
+		--security-opt seccomp:unconfined --cap-add=SYS_PTRACE \
+		-e PYTHONHASHSEED=1 \
+		cpython-lldb:$(DOCKER_IMAGE_TAG) \
+		bash


### PR DESCRIPTION
* debug: run tests serially and start a pdb session on the first failure

* shell: start a shell in a container with cpython-lldb installed