### PR TITLE
ci: fix warnings in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
@@ -27,14 +27,14 @@ jobs:
       - id: release_params
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "::set-output name=prerelease::false"
-            echo "::set-output name=release_tag::${GITHUB_REF#refs/tags/}"
-            echo "::set-output name=title::${GITHUB_REF#refs/tags/}"
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "release_tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+            echo "title=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           else
             git fetch --tags
-            echo "::set-output name=prerelease::true"
-            echo "::set-output name=release_tag::$(git tag --list --sort=version:refname | grep -v dev | tail -n 1)-dev"
-            echo "::set-output name=title::Development Build"
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "release_tag=$(git tag --list --sort=version:refname | grep -v dev | tail -n 1)-dev" >> $GITHUB_OUTPUT
+            echo "title=Development Build" >> $GITHUB_OUTPUT
           fi
 
       - name: Build artifacts


### PR DESCRIPTION
Still need to figure out what to do with marvinpinto/action-automatic-releases, which seems to have been abandoned.