### PR TITLE
Use the C-extension for testing pretty printers

### DIFF
--- a/tests/test_extension/setup.py
+++ b/tests/test_extension/setup.py
@@ -4,6 +4,9 @@ setup(
     ext_modules=[
         Extension('test_extension._test_extension',
                   sources=['test_extension/test_extension.c'],
-                  extra_compile_args=['-g']),
+                  extra_compile_args=[
+                    '-g',   # generate debug symbols
+                    '-O0',  # disable compiler optimizations
+                  ]),
     ]
 )

--- a/tests/test_extension/test_extension/test_extension.c
+++ b/tests/test_extension/test_extension/test_extension.c
@@ -51,9 +51,26 @@ static PyObject* eggs(PyObject* self, PyObject* args, PyObject* kwargs) {
     return PyObject_CallObject(f, argslist);
 }
 
+// Helper functions for testing pretty-printing of Python objects. The problem
+// with using functions built into CPython (e.g. id()) is that breakpoints may
+// not trigger if such function is inlined. And with this C-extension we have
+// full control of the compiler options and can disable optimizations.
+static PyObject* _identity(PyObject* v) {
+    return v;
+}
+static PyObject* identity(PyObject* self, PyObject* args) {
+    PyObject* v = NULL;
+    if (!PyArg_ParseTuple(args, "O", &v) || v == NULL) {
+        return NULL;
+    }
+
+    return _identity(v);
+}
+
 static PyMethodDef methods[] = {
     { "spam", spam, METH_NOARGS, "Test Extension Function" },
     { "eggs", eggs, METH_VARARGS | METH_KEYWORDS, "Test Extension Function" },
+    { "identity", identity, METH_VARARGS, "Returns the passed value. Used in testing." },
     { NULL, NULL, 0, NULL }
 };
 


### PR DESCRIPTION
The tests started to fail on Python 3.10 + LLDB 11 recently. The issue is with that particular CPython build from the corresponding official Docker image: the interpreter is built with all optimizations enabled, and builtin_id() is inlined, which means our breakpoint is no longer hit.

Previously, we had to resort to relying on the AMD64 calling convention for finding the variable we try to pretty-print in tests. That worked, but was unnecessarily annoying.

To avoid all that trouble, create a helper function in the C-extension that we already use for testing. Here we have full control over the compiler options used and we can disable optimizations to get simpler and more reliable tests.